### PR TITLE
Update compile-sketch.yml

### DIFF
--- a/.github/workflows/compile-sketch.yml
+++ b/.github/workflows/compile-sketch.yml
@@ -71,6 +71,13 @@ jobs:
           # SparkFun_LPS25HB_Arduino_Library.cpp uses #include <SparkFun_LPS25HB_Arduino_Library.h>. We need to replace the < and > with double quotes
           sed -i 's/<SparkFun_LPS25HB_Arduino_Library.h>/'\"'SparkFun_LPS25HB_Arduino_Library.h'\"'/g' SparkFun_LPS25HB_Arduino_Library.cpp
 
+      - name: Update LSM6DSO
+        run: |
+          cd ./src/src/
+          mkdir -p LSM6DSO
+          cd LSM6DSO
+          curl -O https://raw.githubusercontent.com/sparkfun/SparkFun_Qwiic_6DoF_LSM6DSO_Arduino_Library/refs/heads/main/src/SparkFunLSM6DSO.h
+          curl -O https://raw.githubusercontent.com/sparkfun/SparkFun_Qwiic_6DoF_LSM6DSO_Arduino_Library/refs/heads/main/src/SparkFunLSM6DSO.cpp
       - name: Update MAX1704X
         run: |
           cd ./src/src/


### PR DESCRIPTION
updated .github/workflows/compile-sketch.yml  to include the LSM6DSO Arduino Library located at: https://github.com/sparkfun/SparkFun_Qwiic_6DoF_LSM6DSO_Arduino_Library